### PR TITLE
Put node shebang in main.ts

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 import { Builtins, Cli } from "clipanion";
 
 import { getPackageVersion } from "./common.js";


### PR DESCRIPTION
This allows use of the CLI under windows under npm -g install. Otherwise trying to run `every-ts` from cmd just opens the entrypoint JS file in a code editor